### PR TITLE
Fix "onMillis" and "currentMillis" variables data types to align millis() return type

### DIFF
--- a/src/ratgdo.cpp
+++ b/src/ratgdo.cpp
@@ -407,7 +407,7 @@ void IRAM_ATTR isrObstruction(){
 
 void obstructionLoop(){
 	if(!obstructionSensorDetected) return;
-	long currentMillis = millis();
+	unsigned long currentMillis = millis();
 	static unsigned long lastMillis = 0;
 
 	// the obstruction sensor has 3 states: clear (HIGH with LOW pulse every 7ms), obstructed (HIGH), asleep (LOW)
@@ -670,8 +670,8 @@ void pullLow(){
 
 void blink(bool trigger){
 	if(LED_BUILTIN == OUTPUT_GDO) return;
-	static unsigned int onMillis = 0;
-	unsigned int currentMillis = millis();
+	static unsigned long onMillis = 0;
+	unsigned long currentMillis = millis();
 
 	if(trigger){
 		digitalWrite(LED_BUILTIN,LOW);


### PR DESCRIPTION
Related indirectly to [issue 45](https://github.com/ratgdo/mqtt-ratgdo/issues/45).

The millis() function returns an "unsigned long" which is 32 bits on Arduino devices.

It's not a bad idea to define variables working with/against millis() as "unsigned long" similar to this [recent commit in the homekit firmware](https://github.com/ratgdo/homekit-ratgdo/commit/d5f410a452e1c24246a8682a528a56821ca1c30b).